### PR TITLE
Allow non-default fields to be requested

### DIFF
--- a/php/WporgClient.php
+++ b/php/WporgClient.php
@@ -35,7 +35,12 @@ class WporgClient extends GuzzleClient
         'tags'          => false,
         'donate_link'   => false,
     ];
-    
+
+    protected function getRequestFields($fields)
+    {
+        return is_array($fields) ? array_merge($this->disabledFields, array_fill_keys($fields, true)) : [];
+    }
+
     public static function getClient(Client $client = null, Description $description = null, array $config = [ ])
     {
         if (empty( $client )) {
@@ -144,7 +149,7 @@ class WporgClient extends GuzzleClient
                 $type      => $value,
                 'page'     => $page,
                 'per_page' => $perPage,
-                'fields'   => is_array($fields) ? array_diff_key($this->disabledFields, array_flip($fields)) : [ ],
+                'fields'   => $this->getRequestFields($fields),
             ],
         ]);
 
@@ -159,7 +164,7 @@ class WporgClient extends GuzzleClient
             'action'  => 'plugin_information',
             'request' => [
                 'slug'   => $slug,
-                'fields' => is_array($fields) ? array_diff_key($this->disabledFields, array_flip($fields)) : [ ],
+                'fields' => $this->getRequestFields($fields),
             ]
         ]);
 
@@ -204,7 +209,7 @@ class WporgClient extends GuzzleClient
                 $type      => $value,
                 'page'     => $page,
                 'per_page' => $perPage,
-                'fields'   => is_array($fields) ? array_diff_key($this->disabledFields, array_flip($fields)) : [ ],
+                'fields'   => $this->getRequestFields($fields),
             ],
         ]);
 

--- a/php/WporgClient.php
+++ b/php/WporgClient.php
@@ -116,9 +116,14 @@ class WporgClient extends GuzzleClient
         return $this->execute($command);
     }
 
-    public function getTheme($slug)
+    public function getTheme($slug, $fields = null)
     {
-        $response = $this->getThemesInfo([ 'request' => [ 'slug' => $slug ] ]);
+        $response = $this->getThemesInfo([
+            'request' => [
+                'slug'   => $slug,
+                'fields' => $this->getRequestFields($fields)
+            ]
+        ]);
 
         return $response['body'];
     }


### PR DESCRIPTION
The previous logic would disable all fields except those supplied in `$fields` however that doesn't work for fields that are disabled by default (e.g. `versions`). Need to explicitly request those so the new logic does an array merge instead.
