### PR TITLE
Fix broken dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require"    : {
         "guzzlehttp/guzzle"         : "^6.2.2",
-        "guzzlehttp/guzzle-services": "1.*"
+        "guzzlehttp/guzzle-services": "1.0.*"
     },
     "autoload"   : {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require"    : {
         "guzzlehttp/guzzle"         : "^6.2.2",
-        "guzzlehttp/guzzle-services": "^1.0"
+        "guzzlehttp/guzzle-services": "1.*"
     },
     "autoload"   : {
         "psr-4": {


### PR DESCRIPTION
When version 1.1.0 of `guzzle-services` is used, the following error is displayed:

Code:
```
$wporgClient = WporgClient::getClient();
$info = $wporgClient->getPlugin('english-wp-admin', ['versions']);
```

Output:
```
  [GuzzleHttp\Command\Exception\CommandException]     
  Validation errors: [request] must be of type array  
```

Setting the dependency back to `1.0.*` so the package works until the issue can be resolved fully.